### PR TITLE
Suppress insecure HTTPS request warnings

### DIFF
--- a/accli/__init__.py
+++ b/accli/__init__.py
@@ -1,3 +1,8 @@
+import urllib3
+from urllib3.exceptions import InsecureRequestWarning
+
+urllib3.disable_warnings(InsecureRequestWarning)
+
 from accli._version import VERSION
 
 from accli.cli import app


### PR DESCRIPTION
## Summary

- suppress urllib3 InsecureRequestWarning during application configuration

This warning muddies up the logs and makes it hard to focus on useful logs.

